### PR TITLE
expire index, rawCollection, test

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Optionally add an [Accounts Throttling](https://atmospherejs.com/zeroasterisk/th
 
 *(NOTE for Throttle Accounts, you have to Configure it, see that package's README)*
 
+## Version
+
+Used `rawCollection` from `Meteor@1.0.4`, for early Meteor you can use this package <= v0.3.0
+
 ## Configuration
 
     if (Meteor.isServer) {

--- a/package.js
+++ b/package.js
@@ -17,5 +17,7 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   api.use("zeroasterisk:throttle");
   api.use('tinytest@1.0.0');
+  api.use('underscore');
+  api.use('meteor');
   api.addFiles('throttle_tests.js', ['client', 'server']);
 });

--- a/package.js
+++ b/package.js
@@ -2,12 +2,12 @@
 Package.describe({
   name: "zeroasterisk:throttle",
   summary: "A secure means of limiting interactions (emails, etc)",
-  version: "0.3.0",
+  version: "0.3.1",
   git: "https://github.com/zeroasterisk/Meteor-Throttle.git"
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom("0.9.0");
+  api.versionsFrom("1.0.4");
   api.use(['meteor', 'underscore'], 'server');
   // Export the object 'Throttle' to packages or apps that use this package.
   api.export('Throttle', 'server');

--- a/throttle.js
+++ b/throttle.js
@@ -13,6 +13,7 @@ if (Meteor.isServer) {
 
   Throttle = new Meteor.Collection('throttles');
   Throttle._ensureIndex({key: 1});
+  Throttle._ensureIndex({expire: 1}); // we use query for remove
   Throttle.debug = false;
   // scope: normal, user
   //   if set to "user" all keys will become user specific not global

--- a/throttle.js
+++ b/throttle.js
@@ -27,7 +27,7 @@ if (Meteor.isServer) {
     if (this.debug) {
       console.log('Throttle.setDebugMode(' + bool + ')');
     }
-  }
+  };
 
   // Access to set the Throttle.debug Boolean
   Throttle.setScope = function(scope) {
@@ -36,7 +36,7 @@ if (Meteor.isServer) {
     if (this.debug) {
       console.log('Throttle.setScope(' + scope + ')');
     }
-  }
+  };
 
   // Modify the key based on Throttle.scope
   Throttle.keyScope = function(key) {
@@ -52,7 +52,7 @@ if (Meteor.isServer) {
       }
     }
     return key;
-  }
+  };
 
   // check to see if we've done something too many times
   // if we "pass" then go ahead and set... (shortcut)
@@ -60,7 +60,7 @@ if (Meteor.isServer) {
     if (!this.check(key, allowed)) {
       return false;
     }
-    return this.set(key, expireInMS)
+    return this.set(key, expireInMS);
   };
 
   // check to see if we've done something too many times
@@ -77,9 +77,8 @@ if (Meteor.isServer) {
     var raw    = this.rawCollection(),
         cursor = Meteor.wrapAsync (raw.find, raw) ({ key: key }),
         count  = Meteor.wrapAsync (cursor.count, cursor) ();
-    console.log('count', count);
     return (count < allowed);
-  }
+  };
 
   // create a record with
   Throttle.set = function(key, expireInMS) {

--- a/throttle.js
+++ b/throttle.js
@@ -87,7 +87,7 @@ if (Meteor.isServer) {
     if (!_.isNumber(expireInMS)) {
       expireInMS = 180000; // 3 min, default expire timestamp
     }
-    var expireEpoch = this.epoch() + expireInMS;
+    var expireEpoch = +new Date() + expireInMS;
     if (Throttle.debug) {
       console.log('Throttle.set(', key, expireInMS, ')');
     }
@@ -102,16 +102,10 @@ if (Meteor.isServer) {
 
   // remove expired records
   Throttle.purge = function() {
-    var now = this.epoch();
-    var raw = this.rawCollection();
+    var now = +new Date(),
+        raw = this.rawCollection();
     Meteor.wrapAsync (raw.remove, raw) ({ expire: {$lt: now } });
   };
-
-  // simple tool to get a standardized epoch/timestamp
-  Throttle.epoch = function() {
-    var now = new Date;
-    return now.getTime();
-  }
 
   // expose some methods for easy access into Throttle from the client
   Meteor.methods({

--- a/throttle_tests.js
+++ b/throttle_tests.js
@@ -1,1 +1,56 @@
-// See https://github.com/dandv/meteor-crypto-base64/blob/master/crypto-base64_tests.js for a simple example// See https://www.eventedmind.com/feed/e6gJZXNQWyNP2MLsb for more on testing with Tinytest
+if (Meteor.isServer) {
+  Tinytest.add('Drop old test data', function(test) {
+    return Throttle.remove({});
+  });
+
+  Tinytest.add('Throttle.checkThenSet, test throttle 2 checks in 10 sec', function(test) {
+    function throttle10() {
+      return Throttle.checkThenSet('server-check-10sec', 2, 10000);
+    }
+    test.isTrue(throttle10());
+    test.isTrue(throttle10());
+    test.isFalse(throttle10());
+    test.isFalse(throttle10());
+    test.isFalse(throttle10());
+    // now sleep for 12 seconds
+    Meteor._sleepForMs(12000);
+    test.isTrue(throttle10());
+    test.isTrue(throttle10());
+    test.isFalse(throttle10());
+    return test.isFalse(throttle10());
+  });
+}
+
+if (Meteor.isClient) {
+  Tinytest.addAsync("client throttle method (2, 10sec) #1 must be true", function(test, next) {
+    Meteor.call('throttle', 'client-check-10sec', 2, 10000, function(err, res) {
+      test.isUndefined(err);
+      test.isTrue(res);
+      next();
+    });
+  });
+  Tinytest.addAsync("client throttle method (2, 10sec) #2 must be true", function(test, next) {
+    Meteor.call('throttle', 'client-check-10sec', 2, 10000, function(err, res) {
+      test.isUndefined(err);
+      test.isTrue(res);
+      next();
+    });
+  });
+  Tinytest.addAsync("client throttle method (2, 10sec) #3 must be false", function(test, next) {
+    Meteor.call('throttle', 'client-check-10sec', 2, 10000, function(err, res) {
+      test.isUndefined(err);
+      test.isFalse(res);
+      next();
+    });
+  });
+
+  Tinytest.addAsync("client throttle method (2, 10sec) #4 after 11sec must be true", function(test, next) {
+    _.delay(function() {
+      Meteor.call('throttle', 'client-check-10sec', 2, 10000, function(err, res) {
+        test.isUndefined(err);
+        test.isTrue(res);
+        next();
+      });
+    }, 11000);    
+  });
+}


### PR DESCRIPTION
Hello, in this patch:

* test, client/server throtle.
* find/remove/insert via **rawCollection**. Avoid minimongo, but need update to Meteor@1.0.4 for use rawCollection method, I update package.js for it.
* ensureIndex for **expire** key. When you ander heavy throttling, here may be lot of keys, and  removing may be slow! Btw, MongoDB can remove expired records  `ensureIndex({expire: 1}){expireAfterSeconds}`, but mongo use worker that purge every 60sec, not perfect.

 Also how about throttle `purge()` method:
```js
  // remove expired records, rate limit to 250 ms, does we really need faster?
  Throttle._purgeThrottle = 0;
  Throttle.purge = function() {
    var now = this.epoch();
    if (this._purgeThrottle < now) {      
      this._purgeThrottle = now + 250;
      var raw = this.rawCollection();
      Meteor.wrapAsync (raw.remove, raw) ({ expire: {$lt: now } });
    }
  };

```