### PR TITLE
Throttle.noMethods for method expose control

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ Optionally add an [Accounts Throttling](https://atmospherejs.com/zeroasterisk/th
 
 ## Configuration
 
+```js
     if (Meteor.isServer) {
       // core Throttle config
       Throttle.setDebugMode(true); // default = false
       Throttle.setScope("user");   // default = global
+      Throttle.noMethods = true;   // Disable client-side methods, default = false
     }
+```
 
 ## Usage On Client (Meteor.call)
 
@@ -85,6 +88,14 @@ and over again, even if a user triggered it.
 * `throttle-check(key, allowedCount)` --> `Throttle.check()`
 * `throttle-set(key, expireInMS)` --> `Throttle.set()`
 * `throttle-debug(bool)` --> pass in true/false to toggle server loggin on checks
+
+If you don't planning to use methods, better if you disable it:
+
+```js
+if (Meteor.isServer) {
+  Throttle.noMethods = true;
+}
+```
 
 *(no set-scope method, because that would be insecure)*
 

--- a/throttle.js
+++ b/throttle.js
@@ -19,6 +19,9 @@ if (Meteor.isServer) {
   //   (on server, based on Meteor.userId())
   Throttle.scope = 'normal';
 
+  // disable exposing methods
+  Throttle.noMethods = false;
+
   // Access to set the Throttle.debug Boolean
   Throttle.setDebugMode = function(bool) {
     check(bool, Boolean);
@@ -103,25 +106,35 @@ if (Meteor.isServer) {
     return now.getTime();
   }
 
+  // Rise exception if disabled client-side methods
+  var checkAllowedMethods = function()  {
+    if (Throttle.noMethods)
+      throw new Meteor.Error(403, 'Client-side throttle disabled');
+  };
+
   // expose some methods for easy access into Throttle from the client
   Meteor.methods({
     'throttle': function(key, allowed, expireInMS) {
+      checkAllowedMethods();
       check(key, String);
       check(allowed, Match.Integer);
       check(expireInMS, Match.Integer);
       return Throttle.checkThenSet(key, allowed, expireInMS);
     },
     'throttle-set': function(key, expireInMS) {
+      checkAllowedMethods();
       check(key, String);
       check(expireInMS, Match.Integer);
       return Throttle.set(key, expireInMS);
     },
     'throttle-check': function(key, allowed) {
+      checkAllowedMethods();
       check(key, String);
       check(allowed, Match.Integer);
       return Throttle.check(key, allowed);
     },
     'throttle-debug': function(bool) {
+      checkAllowedMethods();
       return Throttle.setDebugMode(bool);
     },
   });


### PR DESCRIPTION
Hello, I think it not secure to allow client doing method throttling. For example client may:
```js
var i = 0;
while(1) {
  i++;
  Meteor.call("throttle", 'key' + i, 999999999, 999999999)
```
I think methods **must be removed for security reason**, if not, may we control exposing?

This patch allow user to disable method by `Throttle.noMethods = true` (default allowed)

Client-side throtle stiil may be done by creating custom methods, that use regular Throttle api, so remove method goo idea :)  