### PR TITLE
Enable Throttle.setCollection() to take Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ This is optional Configuration - if you want to change how Throttle operates.
 
       // Set a MongoDB collection: name, options, or Collection
       //   you can set this to your own 'throttle_collection_name' if you need to
-      //   for a multi-node app you MUST use MongoDB
-      //   for a single-node app you may wan to set null, NodeJS RAM only (no MongoDB)
-      //     but be aware it's NOT faster than MongoDB, unless MongoDB is bottlenecked
+      //   for a multi-node app you MUST use MongoDB (or other shared DB)
+      //   for a single-node app you may want to set null, NodeJS RAM only (no MongoDB)
+      //     but for some workloads it may NOT be faster than MongoDB, because it is not indexed
+      //       You will have to profile for yourself to see which is faster...
       //     https://github.com/zeroasterisk/Meteor-Throttle/pull/10 (see profiling, thanks @osv)
+      //   Want more customization?  see: setCollection()
       Throttle.setCollectionName("my_throts"); // default = 'throttles'
-      // Throttle.setCollectionName(null);     // not for multi-node apps, not faster in general
+      // Throttle.setCollectionName(null);     // RAM only, no DB, not for multi-node apps
       // Throttle.setCollection(new Mongo.Collection("customForWhat")); // full control over Collection
       // Throttle.setup();                     // verify Collection is set up (automatic, no need to manually call)
       // Throttle.resetSetup();                // if you need to change collection after setup()

--- a/README.md
+++ b/README.md
@@ -38,14 +38,18 @@ This is optional Configuration - if you want to change how Throttle operates.
       // core Throttle config
       // ----------------------------
 
-      // Set a MongoDB collection name
+      // Set a MongoDB collection: name, options, or Collection
       //   you can set this to your own 'throttle_collection_name' if you need to
       //   for a multi-node app you MUST use MongoDB
       //   for a single-node app you may wan to set null, NodeJS RAM only (no MongoDB)
       //     but be aware it's NOT faster than MongoDB, unless MongoDB is bottlenecked
       //     https://github.com/zeroasterisk/Meteor-Throttle/pull/10 (see profiling, thanks @osv)
-      Throttle.setCollection("my_throts"); // default = 'throttles'
-      //Throttle.setCollection(null);      // not for multi-node apps, not faster in general
+      Throttle.setCollectionName("my_throts"); // default = 'throttles'
+      // Throttle.setCollectionName(null);     // not for multi-node apps, not faster in general
+      // Throttle.setCollection(new Mongo.Collection("customForWhat")); // full control over Collection
+      // Throttle.setup();                     // verify Collection is set up (automatic, no need to manually call)
+      // Throttle.resetSetup();                // if you need to change collection after setup()
+      // Throttle.getCollection()._createCappedCollection(numBytes); // access to already setup Collection
 
       // Set the "scope" to "user specific" so every key gets appended w/ userId
       Throttle.setScope("user");          // default = global
@@ -99,7 +103,9 @@ and over again, even if a user triggered it.
 * `check(key, allowedCount)` checks a key, if less than `allowedCount` of the (unexpired) records exist, it passes
 * `set(key, expireInMS)` sets a record for key, and it will expire after `expireInMS` milliseconds, eg: `60000` = 1 min in the future
 * `purge()` expires all records which are no longer within timeframe (automatically called on every check)
-* `setCollection(mixed)` null for no MongoDB, string for MongoDB collection name ['throttles' by default]
+* `setCollectionName(mixed)` null for no MongoDB, string for MongoDB collection name ['throttles' by default]
+* `setCollection(new Mongo.Collection('abc', {}))` set anything you want for the collection
+* `getCollection()` returns the collection (after setup) for manipulation
 * `setScope(bool)` true/false logs details [false by default]
 * `setMethodsAllowed(bool)` true/false allows clientside helper methods [true by default]
 * `setDebugMode(bool)` true/false logs details [false by default]

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
   name: "zeroasterisk:throttle",
   summary: "A secure means of limiting interactions (emails, etc)",
-  version: "0.3.1",
+  version: "0.3.2",
   git: "https://github.com/zeroasterisk/Meteor-Throttle.git"
 });
 

--- a/throttle.js
+++ b/throttle.js
@@ -14,7 +14,9 @@ if (Meteor.isServer) {
   Throttle = {};
 
   // CONFIG
-  // collection name (null for single-node-app, RAM only, no MongoDB)
+  // collection name
+  //   You can set to null for single-node-app, RAM only, no MongoDB
+  //   Want more customization?  see: setCollection()
   Throttle._collectionName = 'throttles';
   // collection options
   Throttle._collectionOptions = {};
@@ -43,7 +45,9 @@ if (Meteor.isServer) {
     this.isSetup = true;
     if (!this._collectionName) {
       // no collectionName = no mongo, RAM only
-      //   NOTE this is actually pretty slow because it is non-indexed
+      //   NOTE that null (RAM ONLY) will not work on a multi-app setup
+      //   Also note that this may not be faster because it is non-indexed
+      //     (depending on your usage)
       this._collection = new Mongo.Collection(null, this._collectionOptions);
       return;
     }
@@ -61,6 +65,8 @@ if (Meteor.isServer) {
 
   // clear existing setup (allowing for changing _collectionName)
   Throttle.resetSetup = function() {
+    delete Throttle._collection;
+    Throttle._collection = null;
     this.isSetup = false;
   };
 

--- a/throttle_tests.js
+++ b/throttle_tests.js
@@ -1,1 +1,165 @@
-if (Meteor.isClient) {}if (Meteor.isServer) {  /* -- *  Tinytest.add('Throttle - Setup & Config', function (test) {    if (Meteor.isClient) {      return;    }    // verify base config    test.equal(      Throttle.isSetup,      false,      'config: isSetup = false'    );    test.equal(      Throttle._collectionName,      'throttles',      'config: _collectionName = throttles'    );    test.equal(      Throttle.debug,      false,      'config: debug = false'    );    test.equal(      Throttle.scope,      'normal',      'config: scope = normal'    );    test.equal(      Throttle.isMethodhelpersAllowed,      true,      'config: isMethodhelpersAllowed = true'    );  });  /* -- */  Tinytest.add('Throttle - setup', function (test) {    if (Meteor.isClient) {      return;    }    // reset    Throttle.resetSetup();    test.equal(      Throttle.isSetup,      false,      'after setup(): isSetup = true'    );    // config    Throttle.setCollection(null);    Throttle.setup();    // verify base config    test.equal(      Throttle.isSetup,      true,      'after setup(): isSetup = true'    );    test.equal(      Throttle._collectionName,      null,      'after setup(): _collectionName = null'    );  });  Tinytest.add('Throttle - keyScope', function (test) {    // mockery    var userIdFunc = Meteor.userId;    Meteor.userId = function() { return 'throttleTinyTestMockUserId'; };    var scope = Throttle.scope;    Throttle.setScope('global');    test.equal(      Throttle.keyScope('mykey'),      'mykey'    );    Throttle.setScope('user');    test.equal(      Throttle.keyScope('mykey'),      'mykey_u_throttleTinyTestMockUserId'    );    // revert mockery    Meteor.userId = userIdFunc;    Throttle.setScope(scope);  });  Tinytest.add('Throttle - checkThenSet', function (test) {    // reset    Throttle.resetSetup();    test.equal(      Throttle.isSetup,      false,      'after setup(): isSetup = true'    );    // config    Throttle.setCollection(null);    Throttle.setup();    Throttle._collection.remove({});    // tests    test.isTrue(      Throttle.checkThenSet('tinytest-checkThenSet', 1, 1000),      'checkThenSet: first time = true'    );    test.isFalse(      Throttle.checkThenSet('tinytest-checkThenSet', 1, 1000),      'checkThenSet: second time = false (1 allowed)'    );    test.isTrue(      Throttle.checkThenSet('tinytest-checkThenSet', 2, 1000),      'checkThenSet: second time, try 2 = true (2 allowed)'    );    test.isFalse(      Throttle.checkThenSet('tinytest-checkThenSet', 2, 1000),      'checkThenSet: third time = false (2 allowed)'    );    test.isFalse(      Throttle.checkThenSet('tinytest-checkThenSet', 2, 1000),      'checkThenSet: third time = false (2 allowed)'    );  });  Tinytest.add('Throttle - check', function (test) {    // reset    Throttle.resetSetup();    test.equal(      Throttle.isSetup,      false,      'after setup(): isSetup = true'    );    // config    Throttle.setCollection(null);    Throttle.setup();    // mock    var now = new Date;    var expireEpoch = now.getTime() + 100; // 100 ms in the future    Throttle._collection.remove({});    Throttle._collection.insert({      key: 'tinytest-check',      expire: expireEpoch    });    // verify check    test.isTrue(      Throttle.check('tinytest-checkbadkey'),      'check: no results found = pass'    );    test.isFalse(      Throttle.check('tinytest-check', 1),      'check: found 1, allowed 1 = fail'    );    test.isFalse(      Throttle.check('tinytest-check'),      'check: auto-allowed = 1'    );    test.isTrue(      Throttle.check('tinytest-check', 2),      'check: found 1, allowed 2 = pass'    );    // -- add another --    Throttle._collection.insert({      key: 'tinytest-check',      expire: expireEpoch    });    test.isFalse(      Throttle.check('tinytest-check', 2),      'check: found 2, allowed 2 = fail'    );    test.isTrue(      Throttle.check('tinytest-check', 3),      'check: found 2, allowed 3 = pass'    );    // -- add an expire record, doesn't count --    Throttle._collection.insert({      key: 'tinytest-check',      expire: expireEpoch - 200 // 100 ms in the past    });    test.isTrue(      Throttle.check('tinytest-check', 3),      'check: found 2 (one in the past, not found), allowed 3 = pass'    );  });  Tinytest.add('Throttle - purge', function (test) {    // reset    Throttle.resetSetup();    test.equal(      Throttle.isSetup,      false,      'after setup(): isSetup = true'    );    // config    Throttle.setCollection(null);    Throttle.setup();    Throttle._collection.remove({});    // mock    var now = new Date;    var expireEpoch = now.getTime(); // now    Throttle._collection.insert({      key: 'tinytest-purge',      expire: expireEpoch - 1100 // 1.1 sec in the past    });    Throttle._collection.insert({      key: 'tinytest-purge',      expire: expireEpoch + 1100 // 1.1 sec in the future    });    test.equal(      Throttle._collection.find({}).count(),      2,      'before purge: should be 2 records (past and future)'    );    Throttle.purge();    test.equal(      Throttle._collection.find({}).count(),      1,      'after purge: should be 1 record left (in the future)'    );  });  Tinytest.add('Throttle - epoch', function (test) {    var now = new Date;    var expireEpoch = now.getTime();    test.isTrue(      (Throttle.epoch() - expireEpoch) < 2,      'epoch() within 2 ms of "now"'    );    test.isTrue(      (expireEpoch - Throttle.epoch()) < 2,      'epoch() within 2 ms of "now" (future)'    );  });  Tinytest.add('Throttle - checkAllowedMethods', function (test) {    var isMethodhelpersAllowed = Throttle.isMethodhelpersAllowed;    Throttle.setMethodsAllowed(true);    test.isTrue(      Throttle.isMethodhelpersAllowed,      'config correct = true'    );    test.isTrue(      Throttle.checkAllowedMethods(),      'checkAllowedMethods() should be true'    );    Throttle.setMethodsAllowed(false);    test.isFalse(      Throttle.isMethodhelpersAllowed,      'config correct = false'    );    /* throws Meteor.Error(403)... test for it?       test.isFalse(       Throttle.checkAllowedMethods(),       'checkAllowedMethods() should be false'       );       */    // revert    Throttle.isMethodhelpersAllowed = isMethodhelpersAllowed;  });}
+if (Meteor.isClient) {}
+if (Meteor.isServer) {
+  /* -- *  Tinytest.add('Throttle - Setup & Config', function (test) {    if (Meteor.isClient) {      return;    }    // verify base config    test.equal(      Throttle.isSetup,      false,      'config: isSetup = false'    );    test.equal(      Throttle._collectionName,      'throttles',      'config: _collectionName = throttles'    );    test.equal(      Throttle.debug,      false,      'config: debug = false'    );    test.equal(      Throttle.scope,      'normal',      'config: scope = normal'    );    test.equal(      Throttle.isMethodhelpersAllowed,      true,      'config: isMethodhelpersAllowed = true'    );  });  /* -- */
+  Tinytest.add('Throttle - setup', function(test) {
+    if (Meteor.isClient) {
+      return;
+    } // reset
+    Throttle.resetSetup();
+    test.equal(Throttle.isSetup, false, 'after setup(): isSetup = true'); // config
+    Throttle.setCollection(new Mongo.Collection(null));
+    Throttle.setup(); // verify base config
+    test.equal(Throttle.isSetup, true, 'after setup(): isSetup = true');
+    test.equal(Throttle.getCollection()._connection, null, 'after setup(): getCollection()._connection = null');
+  });
+  Tinytest.add('Throttle - setCollection(new Mongo.Collection(null))', function(test) {
+    if (Meteor.isClient) {
+      return;
+    } // reset
+    Throttle.resetSetup(); // config
+    Throttle.setCollection(new Mongo.Collection(null));
+    Throttle.setup(); // verify base config
+    test.equal(Throttle.isSetup, true, 'after setup(): isSetup = true');
+    test.equal(Throttle.getCollection()._connection, null, 'after setup(): getCollection()._connection = null');
+  });
+  Tinytest.add('Throttle - setCollection(new Mongo.Collection("foobar"))', function(test) {
+    if (Meteor.isClient) {
+      return;
+    } // reset
+    Throttle.resetSetup(); // config
+    Throttle.setCollection(new Mongo.Collection("foobar"));
+    Throttle.setup(); // verify base config
+    test.equal(Throttle.isSetup, true, 'after setup(): isSetup = true');
+    test.equal(typeof Throttle.getCollection()._connection, "object", 'after setup(): getCollection()._connection should be an object');
+  });
+  Tinytest.add('Throttle - setCollectionName(null)', function(test) { // DEPRECATING SOON
+    if (Meteor.isClient) {
+      return;
+    } // reset
+    Throttle.resetSetup(); // config
+    Throttle.setCollectionName(null);
+    Throttle.setup(); // verify base config
+    test.equal(Throttle.isSetup, true, 'after setup(): isSetup = true');
+    test.equal(Throttle._collectionName, null, 'after setup(): _collectionName = null');
+    test.equal(Throttle.getCollection()._connection, null, 'after setup(): getCollection()._connection = null');
+  });
+  Tinytest.add('Throttle - setCollectionName("foobar2")', function(test) { // DEPRECATING SOON
+    if (Meteor.isClient) {
+      return;
+    } // reset
+    Throttle.resetSetup(); // config
+    Throttle.setCollectionName("foobar2");
+    Throttle.setup(); // verify base config
+    test.equal(Throttle.isSetup, true, 'after setup(): isSetup = true');
+    test.equal(Throttle._collectionName, "foobar2", 'after setup(): _collectionName = "foobar2"');
+    test.equal(typeof Throttle.getCollection()._connection, "object", 'after setup(): getCollection()._connection should be an object');
+  });
+  Tinytest.add('Throttle - keyScope', function(test) { // mockery
+    var userIdFunc = Meteor.userId;
+    Meteor.userId = function() {
+      return 'throttleTinyTestMockUserId';
+    };
+    var scope = Throttle.scope;
+    Throttle.setScope('global');
+    test.equal(Throttle.keyScope('mykey'), 'mykey');
+    Throttle.setScope('user');
+    test.equal(Throttle.keyScope('mykey'), 'mykey_u_throttleTinyTestMockUserId'); // revert mockery
+    Meteor.userId = userIdFunc;
+    Throttle.setScope(scope);
+  });
+  Tinytest.add('Throttle - checkThenSet', function(test) { // reset
+    Throttle.resetSetup();
+    test.equal(Throttle.isSetup, false, 'after setup(): isSetup = true'); // config
+    Throttle.setCollection(new Mongo.Collection(null));
+    Throttle.setup();
+    Throttle._collection.remove({}); // tests
+    test.isTrue(Throttle.checkThenSet('tinytest-checkThenSet', 1, 1000), 'checkThenSet: first time = true');
+    test.isFalse(Throttle.checkThenSet('tinytest-checkThenSet', 1, 1000), 'checkThenSet: second time = false (1 allowed)');
+    test.isTrue(Throttle.checkThenSet('tinytest-checkThenSet', 2, 1000), 'checkThenSet: second time, try 2 = true (2 allowed)');
+    test.isFalse(Throttle.checkThenSet('tinytest-checkThenSet', 2, 1000), 'checkThenSet: third time = false (2 allowed)');
+    test.isFalse(Throttle.checkThenSet('tinytest-checkThenSet', 2, 1000), 'checkThenSet: third time = false (2 allowed)');
+  });
+  Tinytest.add('Throttle - check', function(test) { // reset
+    Throttle.resetSetup();
+    test.equal(Throttle.isSetup, false, 'after setup(): isSetup = true'); // config
+    Throttle.setCollection(new Mongo.Collection(null));
+    Throttle.setup(); // mock
+    var now = new Date;
+    var expireEpoch = now.getTime() + 100; // 100 ms in the future
+    Throttle._collection.remove({});
+    Throttle._collection.insert({
+      key: 'tinytest-check',
+      expire: expireEpoch
+    }); // verify check
+    test.isTrue(Throttle.check('tinytest-checkbadkey'), 'check: no results found = pass');
+    test.isFalse(Throttle.check('tinytest-check', 1), 'check: found 1, allowed 1 = fail');
+    test.isFalse(Throttle.check('tinytest-check'), 'check: auto-allowed = 1');
+    test.isTrue(Throttle.check('tinytest-check', 2), 'check: found 1, allowed 2 = pass'); // -- add another --
+    Throttle._collection.insert({
+      key: 'tinytest-check',
+      expire: expireEpoch
+    });
+    test.isFalse(Throttle.check('tinytest-check', 2), 'check: found 2, allowed 2 = fail');
+    test.isTrue(Throttle.check('tinytest-check', 3), 'check: found 2, allowed 3 = pass'); // -- add an expire record, doesn't count --
+    Throttle._collection.insert({
+      key: 'tinytest-check',
+      expire: expireEpoch - 200 // 100 ms in the past
+    });
+    test.isTrue(Throttle.check('tinytest-check', 3), 'check: found 2 (one in the past, not found), allowed 3 = pass');
+  });
+  Tinytest.add('Throttle - purge', function(test) { // reset
+    Throttle.resetSetup(); // config
+    Throttle.setCollection(new Mongo.Collection(null));
+    Throttle.setup();
+    Throttle._collection.remove({}); // mock
+    var now = new Date;
+    var expireEpoch = now.getTime(); // now
+    Throttle._collection.insert({
+      key: 'tinytest-purge',
+      expire: expireEpoch - 1100 // 1.1 sec in the past
+    });
+    Throttle._collection.insert({
+      key: 'tinytest-purge',
+      expire: expireEpoch + 1100 // 1.1 sec in the future
+    });
+    test.equal(Throttle._collection.find({}).count(), 2, 'before purge: should be 2 records (past and future)');
+    Throttle.purge();
+    test.equal(Throttle._collection.find({}).count(), 1, 'after purge: should be 1 record left (in the future)');
+  });
+  Tinytest.add('Throttle - epoch', function(test) {
+    var now = new Date;
+    var expireEpoch = now.getTime();
+    test.isTrue((Throttle.epoch() - expireEpoch) < 2, 'epoch() within 2 ms of "now"');
+    test.isTrue((expireEpoch - Throttle.epoch()) < 2, 'epoch() within 2 ms of "now" (future)');
+  });
+  Tinytest.add('Throttle - checkAllowedMethods', function(test) {
+    var isMethodhelpersAllowed = Throttle.isMethodhelpersAllowed;
+    Throttle.setMethodsAllowed(true);
+    test.isTrue(Throttle.isMethodhelpersAllowed, 'config correct = true');
+    test.isTrue(Throttle.checkAllowedMethods(), 'checkAllowedMethods() should be true');
+    Throttle.setMethodsAllowed(false);
+    test.isFalse(Throttle.isMethodhelpersAllowed, 'config correct = false');
+    /* throws Meteor.Error(403)... test for it?       test.isFalse(       Throttle.checkAllowedMethods(),       'checkAllowedMethods() should be false'       );       */ // revert
+    Throttle.isMethodhelpersAllowed = isMethodhelpersAllowed;
+  });
+  Tinytest.add('Throttle - performance Mongo.Collection("throttle_perf")', function(test) { // reset
+    Throttle.resetSetup(); // config (use default setup)
+    Throttle._collectionName = "throttle_perf";
+    Throttle.setup();
+    Throttle._collection.remove({});
+    for (i = 0; i < 100000; i++) { // cehck then set X times... most will fail, but still doing WORK on the DB the whole time
+      Throttle.checkThenSet('tinytest-checkThenSet', 2, 100);
+    }
+    test.isFalse(Throttle.checkThenSet('tinytest-checkThenSet', 1, 100), 'checkThenSet: should return false');
+  });
+  Tinytest.add('Throttle - performance Mongo.Collection(null)', function(test) { // reset
+    Throttle.resetSetup(); // config
+    Throttle.setCollection(new Mongo.Collection(null));
+    Throttle.setup();
+    Throttle._collection.remove({});
+    for (i = 0; i < 100000; i++) { // cehck then set X times... most will fail, but still doing WORK on the DB the whole time
+      Throttle.checkThenSet('tinytest-checkThenSet', 2, 100);
+    }
+    test.isFalse(Throttle.checkThenSet('tinytest-checkThenSet', 1, 100), 'checkThenSet: should return false');
+  });
+}


### PR DESCRIPTION
* Enable Throttle.setCollection() to take a Collection object,
  allowing full customization
* Create Throttle.getCollection() for simple access to existing collection
* Create Throttle.setCollectionName() for simple renaming of the collection
  NOTE added a deprecated notice to inform of it's future deprecation
* Alter Throttle.setCollection() to remain backwards compatible,
  alias to setCollectionName()
* Update readme

re #11