### PR TITLE
Disable method `throttle-set` DEPRECATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,16 @@ and over again, even if a user triggered it.
 * `resetSetup()` re-setup the Collection, if needed (automatic if `setCollection()` is used)
 
 
-## Methods Methods (call-able)
+## Meteor Methods (call-able)
 
 * `throttle(key, allowedCount, expireInMS)` --> `Throttle.checkThenSet()`
 * `throttle-check(key, allowedCount)` --> `Throttle.check()`
-* `throttle-set(key, expireInMS)` --> `Throttle.set()`
 * `throttle-debug(bool)` --> pass in true/false to toggle server loggin on checks
+* DEPRECATED: `throttle-set(key, expireInMS)` has been disabled due to **insecurity**
+ * it would be too easy to set `expireInMS=1` bypassing validation
+ * the method is still defined to inform anyone who is using it (legacy support)
 
-If you don't planning to use methods, better if you disable it:
+If you don't planning to use methods, better if you disable them:
 
 ```js
 if (Meteor.isServer) {
@@ -129,5 +131,6 @@ if (Meteor.isServer) {
 }
 ```
 
-*(no set-scope method, because that would be insecure)*
+* _NO `throttle-set` method, insecure_
+* _NO `throttle-set-scope` method, insecure_
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ and over again, even if a user triggered it.
 * `resetSetup()` re-setup the Collection, if needed (automatic if `setCollection()` is used)
 
 
-## Meteor Methods (call-able)
+## Meteor Methods (client side call-able)
 
 * `throttle(key, allowedCount, expireInMS)` --> `Throttle.checkThenSet()`
 * `throttle-check(key, allowedCount)` --> `Throttle.check()`
@@ -131,6 +131,22 @@ if (Meteor.isServer) {
 }
 ```
 
+NOTE: some of the Throttle API is not available via methods
+
 * _NO `throttle-set` method, insecure_
 * _NO `throttle-set-scope` method, insecure_
+
+## Alternatives via Underscore
+
+Are you simply trying to rate limit a simple function to prevent flooding, in
+a single process/session?  If so, take a look at Underscore's functions, which
+you already have available thanks to Meteor:
+
+* [`_.throttle`](http://underscorejs.org/#throttle)
+* [`_.debounce`](http://underscorejs.org/#debounce)
+
+These functions only limit the execution of a function, and are not shared
+across multiple application instances, but are useful options none-the-less,
+and much faster if you're only goal is _simple_ rate limiting.
+
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 
 Package.describe({
   name: "zeroasterisk:throttle",
-  summary: "A secure means of limiting interactions (emails, etc)",
+  summary: "A secure means of rate limiting, debounce even in a cluster (emails, etc)",
   version: "0.3.3",
   git: "https://github.com/zeroasterisk/Meteor-Throttle.git"
 });

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
   name: "zeroasterisk:throttle",
   summary: "A secure means of limiting interactions (emails, etc)",
-  version: "0.3.2",
+  version: "0.3.3",
   git: "https://github.com/zeroasterisk/Meteor-Throttle.git"
 });
 

--- a/throttle.js
+++ b/throttle.js
@@ -228,7 +228,15 @@ if (Meteor.isServer) {
       Throttle.checkAllowedMethods();
       check(key, String);
       check(expireInMS, Match.Integer);
+      throw new Meteor.Error(403, 'Client-side throttle-set disabled as insecure');
+      /*
+       * Disabled as insecure
+       *   if you want this functionality, create your own method
+       *   (which is more secure anyway)
+       * https://github.com/zeroasterisk/Meteor-Throttle/issues/13
+       *
       return Throttle.set(key, expireInMS);
+      */
     },
     'throttle-check': function(key, allowed) {
       Throttle.checkAllowedMethods();


### PR DESCRIPTION
DEPRECATED: `throttle-set(key, expireInMS)` has been disabled due to **insecurity**
* it would be too easy to set `expireInMS=1` bypassing validation
* the method is still defined to inform anyone who is using it (legacy support)

fixes #13