### PR TITLE
Fix Throttle.setCollection(null)

### DIFF
--- a/throttle.js
+++ b/throttle.js
@@ -80,7 +80,7 @@ if (Meteor.isServer) {
   // Access to set the Throttle._collectionName string
   //   see setup(), resetSetup(), setCollectionName(), getCollection()
   Throttle.setCollection = function(input) {
-    if (typeof input === "string" || typeof input === "null") {
+    if (typeof input === "string" || input === null) {
       // assume this is _collectionName setting
       return this.setCollectionName(input);
     }


### PR DESCRIPTION
After `Throttle.setCollection(null)`, `_collectionName` is still `'throttles'` and `_collection` is `null`, but `isSetup` is `true`.

This is all because of wrong check:

```js
Throttle.setCollection = function(input) {
    if (typeof input === "string" || typeof input === "null") {
```

Actually, `typeof null !== 'null'`, `typeof null` is `'object'`. So I’ve fixed it with `input === null`